### PR TITLE
human readable names for css modules

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     modules: {
       generateScopedName: (name, filename) => {
         const basename = path.basename(filename);
-        const componentName = basename.replace(".module.scss", "");
+        const componentName = basename.split(".module.scss")[0];
         return `${componentName}-${name}`;
       },
     },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,17 @@
+import path from "path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  css: {
+    modules: {
+      generateScopedName: (name, filename) => {
+        const basename = path.basename(filename);
+        const componentName = basename.replace(".module.scss", "");
+        return `${componentName}-${name}`;
+      },
+    },
+  },
   plugins: [react()],
 });


### PR DESCRIPTION
Instead of random strings - use more human readable names (pattern `componentName-className`) for css modules.

![Screenshot 2021-11-30 at 17 35 20](https://user-images.githubusercontent.com/20808724/144089440-2b18e936-c549-4d9a-a9b0-51fc2b97569a.png)