### PR TITLE
add navigation between recipe pages and introduce minor adjustments for components

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -18,7 +18,7 @@ export function Button({
   onClick,
   className,
   type,
-  to = false,
+  to,
 } = {}) {
   if (to)
     return (
@@ -54,11 +54,11 @@ export function Button({
 
 Button.propTypes = {
   children: PropTypes.node.isRequired,
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
   fullwidth: PropTypes.bool,
   variant: PropTypes.oneOf(["primary", "secondary", "danger"]),
   isDisabled: PropTypes.bool,
   className: PropTypes.string,
   type: PropTypes.string,
-  to: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  to: PropTypes.string,
 };

--- a/src/components/ButtonGroup/ButtonGroup.module.scss
+++ b/src/components/ButtonGroup/ButtonGroup.module.scss
@@ -1,4 +1,5 @@
 .buttonGroup {
-    display: flex;
-    column-gap: 16px;
+  display: flex;
+  column-gap: 16px;
+  margin-top: auto;
 }

--- a/src/components/Container/Container.module.scss
+++ b/src/components/Container/Container.module.scss
@@ -1,15 +1,18 @@
 .container {
-    max-width: 800px;
-    width: 100%;
-    padding: 32px;
-    margin: 0 auto;
-    position: relative;
+  max-width: 800px;
+  width: 100%;
+  padding: 32px;
+  margin: 0 auto;
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 
-    @media (min-width: 800px) {
-        border-radius: 6px;
-        overflow-y: scroll;
-        padding: 48px;
-        min-height: 650px;
-        margin-top: 82px;
-    }
+  @media (min-width: 800px) {
+    border-radius: 6px;
+    overflow-y: scroll;
+    padding: 48px;
+    min-height: 650px;
+    margin-top: 82px;
+  }
 }

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -11,7 +11,9 @@ export const Input = React.forwardRef(
         {...rest}
         className={errorMessage ? styles.errorOutline : ""}
       />
-      <div className={styles.errorMessage}>{errorMessage}</div>
+      {errorMessage && (
+        <div className={styles.errorMessage}>{errorMessage}</div>
+      )}
     </label>
   ),
 );
@@ -25,7 +27,9 @@ export const Textarea = React.forwardRef(
         {...rest}
         className={errorMessage ? styles.errorOutline : ""}
       />
-      <div className={styles.errorMessage}>{errorMessage}</div>
+      {errorMessage && (
+        <div className={styles.errorMessage}>{errorMessage}</div>
+      )}
     </label>
   ),
 );

--- a/src/pages/Login/Login.module.scss
+++ b/src/pages/Login/Login.module.scss
@@ -8,6 +8,7 @@
   padding: 12% 10%;
   gap: 64px;
   text-align: center;
+  margin: auto;
 
   &_icons {
     width: 100%;

--- a/src/pages/Recipes/RecipeDetails/RecipeDetails.jsx
+++ b/src/pages/Recipes/RecipeDetails/RecipeDetails.jsx
@@ -1,10 +1,21 @@
-import React from "react";
+import * as React from "react";
 import { useParams } from "react-router-dom";
+import { Button, ButtonGroup, Text } from "@/components";
 
 function RecipeDetails() {
   const params = useParams();
 
-  return <div>Details {params.id}</div>;
+  return (
+    <>
+      <Text size="h2">Details</Text>
+      <Text>id: {params.id}</Text>
+      <ButtonGroup>
+        <Button variant="secondary" fullwidth to="/recipes">
+          Cofnij
+        </Button>
+      </ButtonGroup>
+    </>
+  );
 }
 
 export default RecipeDetails;

--- a/src/pages/Recipes/RecipeListing/RecipeListing.jsx
+++ b/src/pages/Recipes/RecipeListing/RecipeListing.jsx
@@ -1,5 +1,6 @@
-import React from "react";
+import * as React from "react";
 import { Link } from "react-router-dom";
+import { Button, ButtonGroup } from "@/components";
 import useRecipes from "../hooks/api/useRecipes";
 
 function RecipeListing() {
@@ -25,6 +26,11 @@ function RecipeListing() {
           </li>
         ))}
       </ul>
+      <ButtonGroup>
+        <Button fullwidth to="/recipes/new">
+          Dodaj przepis
+        </Button>
+      </ButtonGroup>
     </>
   );
 }


### PR DESCRIPTION
## What was done in PR:

- add navigation between pages for recipes
- fix proptypes for `Button`
- adjust `Container` to expand for full height and `ButtonGroup` to have top margin that pin it to the bottom of the viewport
- conditionally render error mesages for `Input` and `TextArea`

## Screenshoots

(to ensure that nothing is broken due to introduced changes 🙃)

<img width="401" alt="listing" src="https://user-images.githubusercontent.com/20808724/149672579-33e09ae9-b384-460b-bb02-be6301d0b2d1.png">
<img width="401" alt="login" src="https://user-images.githubusercontent.com/20808724/149672583-bc5ac2fa-f7e6-4972-85da-391fd55ea816.png">
<img width="402" alt="details" src="https://user-images.githubusercontent.com/20808724/149672584-a3b7d7fb-4e82-466f-afde-b5ac309799d8.png">
<img width="403" alt="form" src="https://user-images.githubusercontent.com/20808724/149672585-9d229401-4178-4bda-83fc-951a0716d272.png">


